### PR TITLE
Fix stochastic rounding mask literal for Triton 3.3+    

### DIFF
--- a/offload_adam/kernels/stochastic_rounding.py
+++ b/offload_adam/kernels/stochastic_rounding.py
@@ -26,7 +26,7 @@ def _fp32_to_bf16_sr(x_f32, rand_16bit):
     # Adapted from torchao
     x_f32_bits = tl.cast(x_f32, tl.int32, bitcast=True)
     x_fraction = x_f32_bits & 0xFFFF
-    x_bf16_towards_zero = x_f32_bits & 0xFFFF0000
+    x_bf16_towards_zero = x_f32_bits & (-0x10000)
     x_f32_bits = tl.where(
         rand_16bit < x_fraction, x_bf16_towards_zero + 0x10000, x_bf16_towards_zero
     )
@@ -113,4 +113,3 @@ def adam_step_stochastic_rounding(
         decoupled_weight_decay,
         BLOCK_SIZE,
     )
-


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                 
  - replace the unsigned mask literal `0xFFFF0000` with its signed two's-complement form `-0x10000`
  - keeps the same high-16-bit mask while staying within Triton’s signed `int32` literal range

  ## Testing
  - [x] torch==2.6.0 + triton==3.2.0: original and patched kernels produce bitwise-identical outputs
  - [x] torch==2.6.0 + triton==3.3.0: patched kernel compiles and runs successfully; original literal fails at JIT compile time with: `ValueError: Scalar 4294901760 is out of range for type int32`
